### PR TITLE
Using BetterCodeHub on your Kotlin repo

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,2 @@
+languages:
+- kotlin

--- a/dummy.js
+++ b/dummy.js
@@ -1,0 +1,1 @@
+This is a dummy file

--- a/dummy.js
+++ b/dummy.js
@@ -1,1 +1,0 @@
-This is a dummy file

--- a/src/main/java/network/xyo/sdkcorekotlin/boundWitness/dummy.java
+++ b/src/main/java/network/xyo/sdkcorekotlin/boundWitness/dummy.java
@@ -1,0 +1,1 @@
+this is a dummy file for Linguist


### PR DESCRIPTION
Hi Arie, you notified us about your trouble analysing a Kotlin repo. We are working on auto detection of Kotlin, currently we support 16 other technologies out of the box.

But, when a codebase contains Kotlin, you can use a little workaround to get Kotlin code analysed by Better Code Hub. When Kotlin is the *only* technology you need to do step 1. In other cases where Kotlin is one of the technologies you need to do step 2 before we analyse Kotlin.

1 - add a dummy file .java, to get Linguist of GitHub going to identify also at least 1 one of the supported technologies.
2 - add a .bettercodehub.yml with the languages descriptor

Best regards / Groeten Michiel